### PR TITLE
FIX: Atualiza o ID do Google Tag Manager para o novo GTM-KBVSC6C4 e r…

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-W9J8QQDS');</script>
+    })(window,document,'script','dataLayer','GTM-KBVSC6C4');</script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
@@ -34,7 +34,7 @@
     <noscript><link rel="stylesheet" href="/src/index.css"></noscript>
   </head>
   <body>
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W9J8QQDS"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KBVSC6C4"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>

--- a/src/analytics/analytics.ts
+++ b/src/analytics/analytics.ts
@@ -1,5 +1,6 @@
 export const GOOGLE_ADS_ID = 'AW-17354756555';
-export const GTM_ID = 'GTM-W9J8QQDS';
+// export const GTM_ID = 'GTM-W9J8QQDS';
+export const GTM_ID = 'GTM-KBVSC6C4';
 
 const isGtagAvailable = (): boolean => {
   return typeof window !== 'undefined' && typeof window.gtag === 'function';

--- a/src/analytics/usePageView.ts
+++ b/src/analytics/usePageView.ts
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-
-export const GTM_ID = 'GTM-W9J8QQDS';
+import { GTM_ID } from '@/analytics/analytics';
 
 declare global {
   interface Window {


### PR DESCRIPTION
…emove referências ao antigo GTM-W9J8QQDS. Também atualiza o ID de conversão do Google Ads para garantir que os eventos sejam rastreados corretamente.